### PR TITLE
use little endian int

### DIFF
--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -14,7 +14,7 @@ use super::{
 pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
     let py = py_uuid.py();
     let uuid_int_val: u128 = py_uuid.getattr(intern!(py, "int"))?.extract()?;
-    let uuid = Uuid::from_u128(uuid_int_val);
+    let uuid = Uuid::from_u128(uuid_int_val.to_le());
     Ok(uuid.to_string())
 }
 

--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -14,7 +14,7 @@ use super::{
 pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
     let py = py_uuid.py();
     let uuid_int_val: u128 = py_uuid.getattr(intern!(py, "int"))?.extract()?;
-    # we use a little endian conversion for compatibility across platforms, see https://github.com/pydantic/pydantic-core/pull/1372
+    // we use a little endian conversion for compatibility across platforms, see https://github.com/pydantic/pydantic-core/pull/1372
     let uuid = Uuid::from_u128(uuid_int_val.to_le());
     Ok(uuid.to_string())
 }

--- a/src/serializers/type_serializers/uuid.rs
+++ b/src/serializers/type_serializers/uuid.rs
@@ -14,6 +14,7 @@ use super::{
 pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
     let py = py_uuid.py();
     let uuid_int_val: u128 = py_uuid.getattr(intern!(py, "int"))?.extract()?;
+    # we use a little endian conversion for compatibility across platforms, see https://github.com/pydantic/pydantic-core/pull/1372
     let uuid = Uuid::from_u128(uuid_int_val.to_le());
     Ok(uuid.to_string())
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

Construct the uuid with a little endian representation of the int. 

<!-- Please give a short summary of the changes. -->

## Related issue number

After a bit of forensic, I saw that uuid-rs does not convert the endianness of the u128. 

https://github.com/pydantic/pydantic-core/pull/772
and @da
https://github.com/uuid-rs/uuid/issues/406

I tried to use the byte attribute from the python object, so endianness would be handled by python itself. This negated the speed-up I tried to introduce in the first place.

This conversion is a no-op on little endian platforms and should fix the s390x build.

## Checklist

* [ X] Unit tests for the changes exist
* [ ] Documentation reflects the changes where applicable
* [ ] Pydantic tests pass with this `pydantic-core` (except for expected changes)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
